### PR TITLE
Fix setup.py for MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,9 +120,9 @@ def get_package_data():
 def get_version():
 	version_cmd = ['git', 'describe', '--tags']
 	
-	if platform in ("linux2", "linux", "darwin"):
+	if platform in ("linux2", "linux"):
 		version_cmd = ' '.join(version_cmd)
-	elif platform != "win32":
+	elif platform not in ("win32", "darwin"):
 		return
 	
 	return subprocess.check_output(version_cmd).split('-', 1)[0]


### PR DESCRIPTION
On MacOS 11 (Big Sur) with Python 2.7.17, setup.py fails because the "get_version" function does not properly call subprocess.  Subprocess on this system requires each argument (including arg[0]) to be a separate element in an array.