### PR TITLE
[Errno 1] Operation not permitted

### DIFF
--- a/src/mwr/common/cmd_ext.py
+++ b/src/mwr/common/cmd_ext.py
@@ -1,5 +1,7 @@
 import cmd
 import os
+from platform import platform
+
 try:
     import readline
 except ImportError:
@@ -272,7 +274,14 @@ class Cmd(cmd.Cmd):
             self.__history_stack.append(history_file)
             readline.clear_history()
             if history_file != None and os.path.exists(history_file):
-                readline.read_history_file(history_file)
+                try:
+                    # In macOS, this line causes a `[Errno 1] Operation not permitted` if there is a `~/.drozer_history`
+                    readline.read_history_file(history_file)
+                except IOError as e:
+                    if "darwin" in platform().lower()  and str(e).strip() == "[Errno 1] Operation not permitted":
+                        print "Could not access the history file..."
+                    else:
+                        raise e
                 
             readline.parse_and_bind(self.completekey + ": complete")
     


### PR DESCRIPTION
1. Drozer stores the history in ~/.drozer_history
2. If there is a history file, drozer tries to read it.
3. I have no idea why but this `readline.read_history_file(history_file)` leads under macOS to this `Operation not permitted`.
4. If you simply remove the `~<F13>.drozer_history` file, everything
   works perfectly again ...
5. I added a `try except` and a error message so that one can at least
   run drozer again on macOs
   
  This might solve https://github.com/FSecureLABS/drozer/issues/371  and https://github.com/FSecureLABS/drozer/issues/269